### PR TITLE
Use correct variable for docker machine install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   tags: ['docker-compose-install']
 
 - include: machine-install.yml
-  when: docker_compose_install == true
+  when: docker_machine_install == true
   tags: ['docker-machine-install']
 
 #- include: configure.yml


### PR DESCRIPTION
The docker-machine install task should be controlled by docker_machine_install, not docker_compose_install.
