### PR TITLE
Add python3-pip as dependency

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ docker_start: '{{ docker_install }}'
 docker_dependencies:
   - apt-transport-https
   - ca-certificates
-  - python-pip
+  - python3-pip
 
 docker_apt_package: 'docker-ce'
 


### PR DESCRIPTION
This PR will add python3-pip as dependency rather that python-pip as python 2.7 reached EOL.